### PR TITLE
(feature) Tab completions

### DIFF
--- a/.fpm
+++ b/.fpm
@@ -12,4 +12,4 @@
 --rpm-os linux
 --osxpkg-identifier-prefix sh.bork
 
-bin=/usr/local/src/bork lib=/usr/local/src/bork types=/usr/local/src/bork docs/bork.1=/usr/local/share/man/man1/bork.1
+bin=/usr/local/src/bork lib=/usr/local/src/bork types=/usr/local/src/bork pkg=/usr/local/src/bork docs/bork.1=/usr/local/share/man/man1/bork.1

--- a/pkg/after-install.sh
+++ b/pkg/after-install.sh
@@ -6,3 +6,20 @@ fi
 if ! [ -e "/usr/local/bin/bork" ]; then
   ln -s /usr/local/src/bork/bin/bork /usr/local/bin/bork
 fi
+
+## Shell completions
+
+if [ -d "/usr/share/bash-completion/completions/" ]; then
+  ln -s /usr/local/src/bork/pkg/bash_completions.sh /usr/share/bash-completion/completions/bork
+fi
+install_platform=$(uname -s)
+if [ $install_platform = "Darwin" ]; then
+  if ! [ -d "/usr/local/share/zsh/site-functions" ]; then
+    mkdir -p /usr/local/share/zsh/site-functions
+  fi
+  ln -s /usr/local/src/bork/pkg/zsh_completions.sh /usr/local/share/zsh/site-functions/_bork
+else
+  if [ -d "/usr/share/zsh/site-functions/" ]; then
+    ln -s /usr/local/src/bork/pkg/zsh_completions.sh /usr/share/zsh/site-functions/_bork
+  fi
+fi

--- a/pkg/after-uninstall.sh
+++ b/pkg/after-uninstall.sh
@@ -3,3 +3,19 @@
 if [ -L "/usr/local/bin/bork" ]; then
   rm /usr/local/bin/bork
 fi
+
+## Shell completions
+
+if [ -L "/usr/share/bash-completion/completions/bork" ]; then
+  rm /usr/share/bash-completion/completions/bork
+fi
+install_platform=$(uname -s)
+if [ $install_platform = "Darwin" ]; then
+  if [ -L "/usr/local/share/zsh/site-functions/_bork" ]; then
+    rm /usr/local/share/zsh/site-functions/_bork
+  fi
+else
+  if [ -L "/usr/share/zsh/site-functions/_bork" ]; then
+    rm /usr/share/zsh/site-functions/_bork
+  fi
+fi

--- a/pkg/bash_completions.sh
+++ b/pkg/bash_completions.sh
@@ -1,6 +1,9 @@
 #/usr/bin/env bash
 
 _bork_completions () {
+  if [ "${#COMP_WORDS[@]}" -gt "1" ]; then
+    return
+  fi
   COMPREPLY=($(compgen -W "check compile do satisfy status inspect types docgen version" "${COMP_WORDS[1]}"))
 }
 

--- a/pkg/bash_completions.sh
+++ b/pkg/bash_completions.sh
@@ -1,10 +1,24 @@
 #/usr/bin/env bash
 
 _bork_completions () {
-  if [ "${#COMP_WORDS[@]}" -gt "1" ]; then
-    return
+  if [ "${#COMP_WORDS[@]}" -le "2" ]; then
+    COMPREPLY=($(compgen -W "check compile do satisfy status inspect types docgen version" "${COMP_WORDS[1]}"))
+  elif [ "${#COMP_WORDS[@]}" -gt "2" ]; then
+    local IFS=$'\n'
+    local LASTCHAR=' '
+
+    COMPREPLY=($(compgen -o plusdirs -f \
+        -- "${COMP_WORDS[COMP_CWORD]}"))
+
+    if [ ${#COMPREPLY[@]} = 1 ]; then
+        [ -d "$COMPREPLY" ] && LASTCHAR=/
+        COMPREPLY=$(printf %q%s "$COMPREPLY" "$LASTCHAR")
+    else
+        for ((i=0; i < ${#COMPREPLY[@]}; i++)); do
+            [ -d "${COMPREPLY[$i]}" ] && COMPREPLY[$i]=${COMPREPLY[$i]}/
+        done
+    fi
   fi
-  COMPREPLY=($(compgen -W "check compile do satisfy status inspect types docgen version" "${COMP_WORDS[1]}"))
 }
 
-complete -F _bork_completions bork
+complete -o nospace -F _bork_completions bork

--- a/pkg/bash_completions.sh
+++ b/pkg/bash_completions.sh
@@ -1,0 +1,7 @@
+#/usr/bin/env bash
+
+_bork_completions () {
+  COMPREPLY=($(compgen -W "check compile do satisfy status inspect types docgen version" "${COMP_WORDS[1]}"))
+}
+
+complete -F _bork_completions bork

--- a/pkg/bash_completions.sh
+++ b/pkg/bash_completions.sh
@@ -1,23 +1,52 @@
 #/usr/bin/env bash
 
+_bork_typelist () {
+  BORK_SOURCE_DIR=$(dirname $(dirname $(realpath $(which bork))))
+  typefiles=$()
+  BORK_TYPES=""
+  for type in $BORK_SOURCE_DIR/types/*.sh; do
+    BORK_TYPES="$BORK_TYPES $(basename $type '.sh')"
+  done
+}
+
 _bork_completions () {
   if [ "${#COMP_WORDS[@]}" -le "2" ]; then
     COMPREPLY=($(compgen -W "check compile do satisfy status inspect types docgen version" "${COMP_WORDS[1]}"))
   elif [ "${#COMP_WORDS[@]}" -gt "2" ]; then
-    local IFS=$'\n'
-    local LASTCHAR=' '
+    case ${COMP_WORDS[1]} in
+      status|satisfy|compile)
+        local IFS=$'\n'
+        local LASTCHAR=' '
 
-    COMPREPLY=($(compgen -o plusdirs -f \
-        -- "${COMP_WORDS[COMP_CWORD]}"))
+        COMPREPLY=($(compgen -o plusdirs -f \
+          -- "${COMP_WORDS[COMP_CWORD]}"))
 
-    if [ ${#COMPREPLY[@]} = 1 ]; then
-        [ -d "$COMPREPLY" ] && LASTCHAR=/
-        COMPREPLY=$(printf %q%s "$COMPREPLY" "$LASTCHAR")
-    else
-        for ((i=0; i < ${#COMPREPLY[@]}; i++)); do
+        if [ ${#COMPREPLY[@]} = 1 ]; then
+          [ -d "$COMPREPLY" ] && LASTCHAR=/
+          COMPREPLY=$(printf %q%s "$COMPREPLY" "$LASTCHAR")
+        else
+          for ((i=0; i < ${#COMPREPLY[@]}; i++)); do
             [ -d "${COMPREPLY[$i]}" ] && COMPREPLY[$i]=${COMPREPLY[$i]}/
-        done
-    fi
+          done
+        fi
+        ;;
+      check|do)
+        if [ "${#COMP_WORDS[@]}" == "3" ]; then
+          COMPREPLY='ok'
+        elif [ "${#COMP_WORDS[@]}" == "4" ]; then
+          _bork_typelist
+          COMPREPLY=$(compgen -W "$BORK_TYPES" "${COMP_WORDS[3]}")
+        else
+          return
+        fi ;;
+      types|inspect)
+        _bork_typelist
+        COMPREPLY=$(compgen -W "$BORK_TYPES" "${COMP_WORDS[2]}") ;;
+      docgen|version)
+        return ;;
+      *)
+        return ;;
+    esac
   fi
 }
 

--- a/pkg/zsh_completions.sh
+++ b/pkg/zsh_completions.sh
@@ -1,6 +1,9 @@
 #compdef bork
 
 _bork () {
+  if [ "${#words[@]}" -gt "2" ]; then
+    return
+  fi
   local -a borkcmds
   borkcmds=(
     "check:perform 'status' for a single command"

--- a/pkg/zsh_completions.sh
+++ b/pkg/zsh_completions.sh
@@ -1,0 +1,19 @@
+#compdef bork
+
+_bork () {
+  local -a borkcmds
+  borkcmds=(
+    "check:perform 'status' for a single command"
+    "compile:compile the config file to a self-contained script output to STDOUT"
+    "do:perform 'satisfy' for a single command"
+    "satisfy:satisfy the config file's conditions if possible"
+    "status:determine if the config file's conditions are met"
+    "inspect:output a Bork config file based on a type's current configuration"
+    "types:list types and their usage information"
+    "docgen:generates documentation under docs/_types for newly-added types"
+    "version:get the currently installed version of bork"
+  )
+  _describe 'bork' borkcmds
+}
+
+_bork

--- a/pkg/zsh_completions.sh
+++ b/pkg/zsh_completions.sh
@@ -2,21 +2,22 @@
 
 _bork () {
   if [ "${#words[@]}" -gt "2" ]; then
-    return
+    _files
+  else
+    local -a borkcmds
+    borkcmds=(
+      "check:perform 'status' for a single command"
+      "compile:compile the config file to a self-contained script output to STDOUT"
+      "do:perform 'satisfy' for a single command"
+      "satisfy:satisfy the config file's conditions if possible"
+      "status:determine if the config file's conditions are met"
+      "inspect:output a Bork config file based on a type's current configuration"
+      "types:list types and their usage information"
+      "docgen:generates documentation under docs/_types for newly-added types"
+      "version:get the currently installed version of bork"
+    )
+    _describe 'bork' borkcmds
   fi
-  local -a borkcmds
-  borkcmds=(
-    "check:perform 'status' for a single command"
-    "compile:compile the config file to a self-contained script output to STDOUT"
-    "do:perform 'satisfy' for a single command"
-    "satisfy:satisfy the config file's conditions if possible"
-    "status:determine if the config file's conditions are met"
-    "inspect:output a Bork config file based on a type's current configuration"
-    "types:list types and their usage information"
-    "docgen:generates documentation under docs/_types for newly-added types"
-    "version:get the currently installed version of bork"
-  )
-  _describe 'bork' borkcmds
 }
 
 _bork

--- a/pkg/zsh_completions.sh
+++ b/pkg/zsh_completions.sh
@@ -1,8 +1,37 @@
 #compdef bork
 
+_bork_typelist () {
+  BORK_SOURCE_DIR=$(dirname $(dirname $(realpath $(which bork))))
+  typefiles=$()
+  BORK_TYPES=()
+  for type in $BORK_SOURCE_DIR/types/*.sh; do
+    BORK_TYPES+=$(basename $type '.sh')
+  done
+}
+
 _bork () {
   if [ "${#words[@]}" -gt "2" ]; then
-    _files
+    case ${words[2]} in
+      status|satisfy|compile)
+        _files ;;
+      check|do)
+        if [ "${#words[@]}" = "3" ]; then
+          assertions=("ok")
+          _describe 'bork' assertions
+        elif [ "${#words[@]}" = "4" ]; then
+          _bork_typelist
+          _describe 'bork' BORK_TYPES
+        else
+          return
+        fi ;;
+      types|inspect)
+        _bork_typelist
+        _describe 'bork' BORK_TYPES ;;
+      docgen|version)
+        return ;;
+      *)
+        return ;;
+    esac
   else
     local -a borkcmds
     borkcmds=(


### PR DESCRIPTION
Closes #19, adds tab completions for bash and zsh.

These will need to be included in packaging code (e.g. Homebrew formula) to have them installed manually.