### PR TITLE
(feature) bork status exit codes

### DIFF
--- a/bin/bork
+++ b/bin/bork
@@ -43,7 +43,11 @@ done
 case "$operation" in
   compile) bork_compile $* ;;
   load) : ;;
-  satisfy | status) . $1 ;;
+  satisfy | status)
+    BORK_EXIT_STATUS=0
+    . $1
+    exit $BORK_EXIT_STATUS
+    ;;
   check)
     fn=$1
     shift

--- a/lib/declarations/ok.sh
+++ b/lib/declarations/ok.sh
@@ -92,6 +92,7 @@ assert () {
       [ "$status" -eq 1 ] && _bork_check_failed=1
       [ "$status" -ne 0 ] && [ -n "$output" ] && echo "$output"
       [ "$assert_mode" = 'no' ] && [ $status -eq $STATUS_MISSING ] && return 0
+      [ "$status" -ne 0 ] && BORK_EXIT_STATUS=$status
       return $status
       ;;
     satisfy)


### PR DESCRIPTION
This turned out to be an easier win than expected…

Closes #10 by keeping track of the last non-zero exit code and exiting with it at the end of a `bork status` run. This is not necessarily the best way to do it — feedback is welcomed — but it certainly does the trick!