### PR TITLE
(bug) (types) Remove Homebrew tap pinning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file, from 2016-0
 
 Changes here will be in the next release. You can use them now by checking out the HEAD of the `main` branch, or specifying the `--HEAD` option with `brew install bork`.
 
+### Fixed
+- Pinning a Homebrew tap [is deprecated and has been removed from Homebrew](https://github.com/Homebrew/brew/pull/5925). The `--pin` option has been removed from the `brew-tap` type accordingly. (#41)
+
 ### Added
 - Bork now supports before hooks. You can define functions named `bork_will_change`, `bork_will_install`, `bork_will_upgrade` or `bork_will_remove`, and Bork will run them just before making any changes. (#16)
 - You can now use the `no` command in place of `ok` to check for the absence, rather than the presence, of an assertion. This will delete files, uninstall packages, etc. when satisfying to ensure an assertion is absent from the system. (#9)

--- a/docs/_types/brew-tap.md
+++ b/docs/_types/brew-tap.md
@@ -9,5 +9,4 @@ Asserts a homebrew formula repository has been tapped. Does NOT assert the updat
 
 ```bash
 > brew-tap homebrew/games    (taps homebrew/games)
---pin                        (pins the formula repository)
 ```

--- a/test/fixtures/brew-tap-pinned.txt
+++ b/test/fixtures/brew-tap-pinned.txt
@@ -1,1 +1,0 @@
-homebrew/games

--- a/test/type-brew-tap.bats
+++ b/test/type-brew-tap.bats
@@ -6,7 +6,6 @@ brew-tap () { . $BORK_SOURCE_DIR/types/brew-tap.sh $*; }
 setup () {
     respond_to "uname -s" "echo Darwin"
     respond_to "brew tap" "cat $fixtures/brew-tap-list.txt"
-    respond_to "brew tap --list-pinned" "cat $fixtures/brew-tap-pinned.txt"
 }
 
 @test "brew-tap status reports missing when untapped" {
@@ -14,59 +13,16 @@ setup () {
     [ "$status" -eq $STATUS_MISSING ]
 }
 
-@test "brew-tap status reports partial when installed but missing pin status" {
-    run brew-tap status railwaycat/emacsmacport --pin
-    [ "$status" -eq $STATUS_PARTIAL ]
-}
-
-@test "brew-tap status reports partial when installed but has pin status when it shouldn't" {
-    run brew-tap status homebrew/games
-    [ "$status" -eq $STATUS_PARTIAL ]
-}
-
-@test "brew-tap status reports ok when installed has correct no-pin status" {
-    run brew-tap status railwaycat/emacsmacport
-    [ "$status" -eq $STATUS_OK ]
-}
-
 @test "brew-tap status reports ok when provided tap name has capitals" {
     run brew-tap status Caskroom/cask
     [ "$status" -eq $STATUS_OK ]
 }
-
-@test "brew-tap status reports ok when installed has correct yes-pin status" {
-    run brew-tap status homebrew/games --pin
-    [ "$status" -eq $STATUS_OK ]
-}
-
 
 @test "brew-tap install installs tap" {
     run brew-tap install homebrew/science
     [ "$status" -eq 0 ]
     run baked_output
     [ "$output" = 'brew tap homebrew/science' ]
-}
-
-@test "brew-tap install installs tap with pin" {
-    run brew-tap install homebrew/science --pin
-    [ "$status" -eq 0 ]
-    run baked_output
-    [[ "brew tap homebrew/science" == ${lines[0]} ]]
-    [[ "brew tap-pin homebrew/science" == ${lines[1]} ]]
-}
-
-@test "brew-tap upgrade with pin adds pin" {
-    run brew-tap upgrade homebrew/science --pin
-    [ "$status" -eq 0 ]
-    run baked_output
-    [ "$output" = "brew tap-pin homebrew/science" ]
-}
-
-@test "brew-tap upgrade without pin removes pin" {
-    run brew-tap upgrade homebrew/science
-    [ "$status" -eq 0 ]
-    run baked_output
-    [ "$output" = "brew tap-unpin homebrew/science" ]
 }
 
 @test "brew-tap inspect: returns FAILED_PRECONDITION without brew exec" {

--- a/types/brew-tap.sh
+++ b/types/brew-tap.sh
@@ -1,14 +1,12 @@
 action=$1
 name="$(echo $2 | awk '{print tolower($0)}')"
 shift 2
-pin=$(arguments get pin $*)
 
 case $action in
     desc)
         echo "asserts a homebrew formula repository has been tapped"
         echo "does NOT assert the updated-ness of a tap's formula - use \`ok brew\`"
         echo "> brew-tap homebrew/games    (taps homebrew/games)"
-        echo "--pin                        (pins the formula repository)"
     ;;
 
     status)
@@ -17,34 +15,14 @@ case $action in
         list=$(bake brew tap)
         echo "$list" | grep -E "$name$" > /dev/null
         [ "$?" -gt 0 ] && return $STATUS_MISSING
-        pinlist=$(bake brew tap --list-pinned)
-        echo "$pinlist" | grep -E "$name$" > /dev/null
-        pinstatus=$?
-        if [ -n "$pin" ]; then
-            [ "$pinstatus" -gt 0 ] && return $STATUS_PARTIAL
-        else
-            [ "$pinstatus" -eq 0 ] && return $STATUS_PARTIAL
-        fi
         return $STATUS_OK ;;
 
     install)
         bake brew tap $name
-        if [ -n "$pin" ]; then
-            bake brew tap-pin $name
-        fi
-        ;;
-
-    upgrade)
-        if [ -n "$pin" ]; then
-            bake brew tap-pin $name
-        else
-            bake brew tap-unpin $name
-        fi
         ;;
 
     inspect)
         # TODO: make this check if the tap comes from anywhere except GitHub
-        # and also check for pinning
         baking_platform_is "Darwin" || return $STATUS_UNSUPPORTED_PLATFORM
         needs_exec "brew" || return $STATUS_FAILED_PRECONDITION
         installed=$(bake brew tap)


### PR DESCRIPTION
Pinning a Homebrew tap [is deprecated and has been removed from Homebrew](Homebrew/brew#5925). This removes the `--pin` option from the `brew-tap` type accordingly.