### PR TITLE
(bug) (types) Workaround for `mas account` failing on macOS >= 12

### DIFF
--- a/lib/helpers/system.sh
+++ b/lib/helpers/system.sh
@@ -48,3 +48,8 @@ baking_platform_is () {
 get_baking_platform () {
   bake uname -s
 }
+
+
+get_baking_platform_release() {
+  bake uname -r
+}

--- a/test/type-mas.bats
+++ b/test/type-mas.bats
@@ -22,6 +22,13 @@ setup () {
     [ "$status" -eq $STATUS_FAILED_PRECONDITION ]
 }
 
+@test "mas status: does not return FAILED_PRECONDITION when mas account fails on macOS >= 12" {
+    respond_to "mas account" "return 1"
+    respond_to "uname -r" "echo 21.4.0"
+    run mas status 497799835 Xcode
+    [ "$status" -eq $STATUS_OK ]
+}
+
 @test "mas status: returns MISSING when app not installed" {
     run mas status 477670270 2Do
     [ "$status" -eq $STATUS_MISSING ]

--- a/test/type-mas.bats
+++ b/test/type-mas.bats
@@ -18,6 +18,7 @@ setup () {
 
 @test "mas status: returns FAILED_PRECONDITION when logged out" {
     respond_to "mas account" "return 1"
+    respond_to "uname -r" "echo 20.0.0"
     run mas status 497799835 Xcode
     [ "$status" -eq $STATUS_FAILED_PRECONDITION ]
 }

--- a/types/mas.sh
+++ b/types/mas.sh
@@ -15,7 +15,9 @@ case $action in
         baking_platform_is "Darwin" || return $STATUS_UNSUPPORTED_PLATFORM
         needs_exec "mas" || return $STATUS_FAILED_PRECONDITION
         bake mas account
-        [ "$?" -gt 0 ] && return $STATUS_FAILED_PRECONDITION
+        # Workaround for mas account failing on macOS >= 12 (i.e. Darwin >= 21)
+        # https://github.com/borksh/bork/issues/42
+        [ "$?" -gt 0 ] && [[ get_baking_platform_release < "21." ]] && return $STATUS_FAILED_PRECONDITION
         bake mas list | grep -E "^$appid" > /dev/null
         [ "$?" -gt 0 ] && return $STATUS_MISSING
         bake mas outdated | grep -E "^$appid" > /dev/null

--- a/types/mas.sh
+++ b/types/mas.sh
@@ -17,7 +17,10 @@ case $action in
         bake mas account
         # Workaround for mas account failing on macOS >= 12 (i.e. Darwin >= 21)
         # https://github.com/borksh/bork/issues/42
-        [ "$?" -gt 0 ] && [[ get_baking_platform_release < "21." ]] && return $STATUS_FAILED_PRECONDITION
+        if [ "$?" -gt 0 ]; then
+          release=$(get_baking_platform_release)
+          str_matches "$release" "^21\." || return $STATUS_FAILED_PRECONDITION
+        fi
         bake mas list | grep -E "^$appid" > /dev/null
         [ "$?" -gt 0 ] && return $STATUS_MISSING
         bake mas outdated | grep -E "^$appid" > /dev/null


### PR DESCRIPTION
Closes https://github.com/borksh/bork/issues/42