### PR TITLE
(bug) (types) Workaround for mas account failing on macOS >= 12... now also include macOS 13

### DIFF
--- a/test/type-mas.bats
+++ b/test/type-mas.bats
@@ -30,6 +30,13 @@ setup () {
     [ "$status" -eq $STATUS_OK ]
 }
 
+@test "mas status: does not return FAILED_PRECONDITION when mas account fails on macOS >= 13" {
+    respond_to "mas account" "return 1"
+    respond_to "uname -r" "echo 22.2.0"
+    run mas status 497799835 Xcode
+    [ "$status" -eq $STATUS_OK ]
+}
+
 @test "mas status: returns MISSING when app not installed" {
     run mas status 477670270 2Do
     [ "$status" -eq $STATUS_MISSING ]

--- a/types/mas.sh
+++ b/types/mas.sh
@@ -19,7 +19,9 @@ case $action in
         # https://github.com/borksh/bork/issues/42
         if [ "$?" -gt 0 ]; then
           release=$(get_baking_platform_release)
-          str_matches "$release" "^21\." || return $STATUS_FAILED_PRECONDITION
+          str_matches "$release" "^21\." || \
+            str_matches "$release" "^22\." || \
+            return $STATUS_FAILED_PRECONDITION
         fi
         bake mas list | grep -E "^$appid" > /dev/null
         [ "$?" -gt 0 ] && return $STATUS_MISSING


### PR DESCRIPTION
Addition to https://github.com/borksh/bork/pull/43

Very obviously super hacky... but it's a quick and dirty GOOD ENOUGH for now...

We experimented with Greater Than Or Equal To stuff in the original PR, but never got it working.

May experiment further at some point... especially as https://github.com/mas-cli/mas/issues/417 appears to be going nowhere fast