### PR TITLE
Permanently skip `mas account` check

### DIFF
--- a/test/type-file.bats
+++ b/test/type-file.bats
@@ -119,7 +119,7 @@ setup () {
 @test "file compile: echoes base64 representation to screen" {
   run file compile path/to/target Readme.md
   [ "$status" -eq 0 ]
-  expected="borkfiles__UmVhZG1lLm1kCg=\"$(base64 Readme.md)\""
+  expected="borkfiles__UmVhZG1lLm1kCg=\"$(cat Readme.md | base64)\""
   accum="${lines[2]}"
   line=2
   while [ "$line" -lt ${#lines[*]} ]; do
@@ -139,7 +139,7 @@ is_compiled () { [ -n "$is_compiled" ]; }
 
 @test "file status: if compiled, uses stored variable" {
   is_compiled=1
-  borkfiles__cGF0aC9mcm9tL3NvdXJjZQo="$(base64 Readme.md)"
+  borkfiles__cGF0aC9mcm9tL3NvdXJjZQo="$(cat Readme.md | base64)"
   respond_to "$(md5cmd $platform path/to/target)" "echo $readsum"
   run file status path/to/target path/from/source
   [ "$status" -eq $STATUS_OK ]
@@ -147,7 +147,7 @@ is_compiled () { [ -n "$is_compiled" ]; }
 
 @test "file install: if compiled, uses stored variable" {
   is_compiled=1
-  borkfiles__cGF0aC9mcm9tL3NvdXJjZQo="$(base64 Readme.md)"
+  borkfiles__cGF0aC9mcm9tL3NvdXJjZQo="$(cat Readme.md | base64)"
   run file install path/to/target path/from/source
   [ "$status" -eq $STATUS_OK ]
   run baked_output

--- a/test/type-mas.bats
+++ b/test/type-mas.bats
@@ -16,27 +16,6 @@ setup () {
     [ "$status" -eq $STATUS_FAILED_PRECONDITION ]
 }
 
-@test "mas status: returns FAILED_PRECONDITION when logged out" {
-    respond_to "mas account" "return 1"
-    respond_to "uname -r" "echo 20.0.0"
-    run mas status 497799835 Xcode
-    [ "$status" -eq $STATUS_FAILED_PRECONDITION ]
-}
-
-@test "mas status: does not return FAILED_PRECONDITION when mas account fails on macOS >= 12" {
-    respond_to "mas account" "return 1"
-    respond_to "uname -r" "echo 21.4.0"
-    run mas status 497799835 Xcode
-    [ "$status" -eq $STATUS_OK ]
-}
-
-@test "mas status: does not return FAILED_PRECONDITION when mas account fails on macOS >= 13" {
-    respond_to "mas account" "return 1"
-    respond_to "uname -r" "echo 22.2.0"
-    run mas status 497799835 Xcode
-    [ "$status" -eq $STATUS_OK ]
-}
-
 @test "mas status: returns MISSING when app not installed" {
     run mas status 477670270 2Do
     [ "$status" -eq $STATUS_MISSING ]

--- a/types/mas.sh
+++ b/types/mas.sh
@@ -14,16 +14,6 @@ case $action in
     status)
         baking_platform_is "Darwin" || return $STATUS_UNSUPPORTED_PLATFORM
         needs_exec "mas" || return $STATUS_FAILED_PRECONDITION
-        bake mas account
-        # Workaround for mas account failing on macOS >= 12 (i.e. Darwin >= 21)
-        # https://github.com/borksh/bork/issues/42
-        if [ "$?" -gt 0 ]; then
-          release=$(get_baking_platform_release)
-            str_matches "$release" "^21\." || \
-            str_matches "$release" "^22\." || \
-            str_matches "$release" "^23\." || \
-            return $STATUS_FAILED_PRECONDITION
-        fi
         bake mas list | grep -E "^$appid" > /dev/null
         [ "$?" -gt 0 ] && return $STATUS_MISSING
         bake mas outdated | grep -E "^$appid" > /dev/null


### PR DESCRIPTION
Given https://github.com/borksh/bork/issues/42 's root cause issue shows no sign of being addressed, just don't run `mas account` anymore

Then I'm implementing https://github.com/borksh/bork/pull/49#issuecomment-1921793529