### PR TITLE
Handle spaces in directory paths

### DIFF
--- a/bin/bork
+++ b/bin/bork
@@ -52,7 +52,7 @@ case "$operation" in
     fn=$1
     shift
     operation=status
-    $fn $* ;;
+    $fn "$@" ;;
   do)
     fn=$1
     shift

--- a/lib/declarations/ok.sh
+++ b/lib/declarations/ok.sh
@@ -157,9 +157,9 @@ assert () {
 }
 
 ok () {
-  assert 'ok' $*
+  assert 'ok' "$@"
 }
 
 no () {
-  assert 'no' $*
+  assert 'no' "$@"
 }

--- a/lib/helpers/bake.sh
+++ b/lib/helpers/bake.sh
@@ -1,1 +1,1 @@
-bake () { eval "$*"; }
+bake () { eval "$@"; }

--- a/test/type-directories.bats
+++ b/test/type-directories.bats
@@ -1,10 +1,10 @@
 #!/usr/bin/env bats
 
 . test/helpers.sh
-directory () { . $BORK_SOURCE_DIR/types/directory.sh $*; }
+directory () { . $BORK_SOURCE_DIR/types/directory.sh "$@"; }
 
 # these tests use live directories in a tempdir
-baking_responder () { eval "$*"; }
+baking_responder () { eval "$@"; }
 
 setup () {
   tmpdir=$(mktemp -d -t bork-dirXXXXXX)
@@ -57,5 +57,15 @@ mkdirs () {
   run directory remove foo
   [ "$status" -eq 0 ]
   run baked_output
-  [ "${lines[0]}" = "rm -r foo" ]
+  [ "${lines[0]}" = "rm -r \"foo\"" ]
+}
+
+@test "directory: handles directories with a space in the path" {
+  mkdir "foo bar"
+  run directory status "foo bar"
+  [ "$status" -eq $STATUS_OK ]
+
+  run directory remove "foo bar"
+  run directory status "foo bar"
+  [ "$status" -eq $STATUS_MISSING ]
 }

--- a/types/directory.sh
+++ b/types/directory.sh
@@ -20,8 +20,8 @@ case "$action" in
     ;;
 
   status)
-    bake [ -e "${dir}" ] || return $STATUS_MISSING
-    bake [ -d "${dir}" ] || {
+    bake "[ -e \"${dir}\" ]" || return $STATUS_MISSING
+    bake "[ -d \"${dir}\" ]" || {
       echo "target exists as non-directory"
       return $STATUS_CONFLICT_CLOBBER
     }
@@ -73,7 +73,7 @@ case "$action" in
     ;;
 
   remove)
-    bake "rm -r ${dir}"
+    bake "rm -r \"${dir}\""
     ;;
 
   *) return 1 ;;


### PR DESCRIPTION
I ran into issues with spaces in directory paths and symlinks, so here's a first patch for getting directories working. I tried to keep it to a minimal surface area.